### PR TITLE
Add typescript defs

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,11 @@
+export function encode(ab: ArrayBuffer): string;
+export function decode(str: string): Uint8Array;
+
+export function from5bit(ab: ArrayBuffer): Uint8Array;
+export function to5bit(ab: ArrayBuffer): number[];
+
+export function fromNumber(int: number): Uint8Array;
+export function toNumber(ab: Uint8Array | number[]): number;
+
+export function encode32bitNumber(int: number): string;
+export function decode32bitNumber(str: string): number;

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "version": "1.0.3",
     "description": "z-base-32 encoding/decoding library",
     "main": "index.js",
+    "typings": "index.d.ts",
     "scripts": {
         "test": "bin/test"
     },


### PR DESCRIPTION
Added typescript definitions in `index.d.ts` so that this package can be more readily used with typescript.

type def format based on https://github.com/beatgammit/base64-js/commit/e9f00fa2fddecfb0bc8d7f7c84b29241e4909cb1